### PR TITLE
fix: Normalise email to lowercase for authentication and registration

### DIFF
--- a/app/src/main/java/com/example/tightbudget/SignupActivity.kt
+++ b/app/src/main/java/com/example/tightbudget/SignupActivity.kt
@@ -225,7 +225,7 @@ class SignupActivity : AppCompatActivity() {
 
     private fun createAccount() {
         val fullName = binding.fullNameInput.text.toString().trim()
-        val email = binding.emailInput.text.toString().trim()
+        val email = binding.emailInput.text.toString().trim().toLowerCase(Locale.ROOT)
         val password = binding.passwordInput.text.toString()
         val confirmPassword = binding.confirmPasswordInput.text.toString()
 

--- a/app/src/main/java/com/example/tightbudget/firebase/FirebaseUserManager.kt
+++ b/app/src/main/java/com/example/tightbudget/firebase/FirebaseUserManager.kt
@@ -192,7 +192,14 @@ class FirebaseUserManager {
      */
     suspend fun authenticateUser(email: String, password: String): User? {
         return try {
-            val user = getUserByEmail(email)
+            // Try lowercase first (new standard)
+            var user = getUserByEmail(email.lowercase())
+
+            // If not found, try original case (for legacy users)
+            if (user == null) {
+                user = getUserByEmail(email)
+            }
+
             if (user != null && user.password == password) {
                 Log.d(TAG, "User authenticated successfully")
                 user


### PR DESCRIPTION
# 📋 Pull Request Title  
**fix: Normalise email to lowercase for authentication and registration**

---

<details>
<summary>✨ Summary (Click to Expand)</summary>

This PR standardises email address handling across registration and login by converting all user-entered emails to lowercase. This resolves issues caused by case sensitivity inconsistencies and ensures smoother authentication flows.

</details>

---

<details>
<summary>🛠 Changes Made (Click to Expand)</summary>

- 🔐 **SignupActivity.kt**:
  - Converts the entered email to lowercase before creating a new account.

- 🔍 **FirebaseUserManager.kt**:
  - `authenticateUser()` now:
    - First attempts login with the lowercase version of the email.
    - If not found, retries using the original casing to support legacy accounts.

</details>

---

## ✅ Testing Checklist

- [x] Registering with uppercase or mixed-case emails saves as lowercase
- [x] Logging in with any casing successfully matches the correct account
- [x] Existing users with mixed-case emails can still log in
- [x] No regression in email-based operations

---

## 🧪 Manual Test Steps

1. Sign up with an email like `User@Example.com`
2. Verify that the email is saved in lowercase in Firebase
3. Attempt login with:
   - `user@example.com`
   - `USER@example.com`
   - `User@Example.com`
4. Confirm successful authentication in all cases

---

## 📌 Notes

- Firebase treats emails as case-insensitive during authentication but stores them as-is.
- This fix ensures consistency and prevents unexpected behaviour in account lookup and user management.